### PR TITLE
vhost: Allow one to specify the vhost servername

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Should the module manage git.
 **Default:** _true_
 Should the module manage the webserver.
 
+#####`ws_servername`
+**Data Type:** _string_
+**Default:** _kibana3_
+Change the default servername for the apache vhost. Only taken into account if `manage_ws => true`.
+
 #####`ws_port`
 **Data Type:** _bool_
 **Default:** _true_

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,10 @@
 # [*manage_ws*]
 #   Should the module manage the webserver.
 #
+# [*ws_servername*]
+#   Specify the virtual host servername . Only taken
+#   into account if manage_ws => true.
+#
 # [*ws_port*]
 #   Change the default port for the webserver to a custom value. Only taken
 #   into account if manage_ws => true.
@@ -86,8 +90,9 @@ class kibana3 (
 
   $manage_git = $::kibana3::params::manage_git,
 
-  $manage_ws = $::kibana3::params::manage_ws,
-  $ws_port   = $::kibana3::params::ws_port,
+  $manage_ws     = $::kibana3::params::manage_ws,
+  $ws_servername = $::kibana3::params::ws_servername,
+  $ws_port       = $::kibana3::params::ws_port,
 
 ) inherits kibana3::params {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,7 +33,7 @@ class kibana3::install {
     }
     ->
     apache::vhost {
-      'kibana3':
+      $::kibana3::ws_servername :
       port          => $::kibana3::ws_port,
       docroot       => "${::kibana3::k3_install_folder}/src",
       docroot_owner => $_ws_user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class kibana3::params {
 
   $manage_git = true
 
-  $manage_ws = true
-  $ws_port   = '80'
+  $manage_ws     = true
+  $ws_servername = 'kibana3'
+  $ws_port       = '80'
 }


### PR DESCRIPTION
This commit aims to allow one to specify the vhost servername
and not force the use of `kibana3` as servername.
