### PR TITLE
install: Use include ::apache rather than calling the class

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,10 +7,7 @@ class kibana3::install {
   }
 
   if $::kibana3::manage_ws {
-    class {
-      'apache':
-      default_vhost => false,
-    }
+    include ::apache
   }
 
   if $::kibana3::k3_folder_owner {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -14,8 +14,7 @@ describe 'kibana3', :type => :class do
       context 'with defaults' do
         it { should compile }
         it { should contain_class('git') }
-        it { should contain_class('apache') \
-          .with_default_vhost(false) }
+        it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
@@ -31,8 +30,7 @@ describe 'kibana3', :type => :class do
         let (:params) {{ :manage_git => false }}
         it { should compile }
         it { should_not contain_class('git') }
-        it { should contain_class('apache') \
-          .with_default_vhost(false) }
+        it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
@@ -61,8 +59,7 @@ describe 'kibana3', :type => :class do
         let (:params) {{ :k3_folder_owner => 'foo' }}
         it { should compile }
         it { should contain_class('git') }
-        it { should contain_class('apache')\
-          .with_default_vhost(false) }
+        it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with(
             'revision' => 'a50a913',
@@ -82,8 +79,7 @@ describe 'kibana3', :type => :class do
         let (:params) {{ :k3_install_folder => '/tmp/kibana3' }}
         it { should compile }
         it { should contain_class('git') }
-        it { should contain_class('apache')\
-          .with_default_vhost(false) }
+        it { should contain_class('apache') }
         it { should contain_vcsrepo('/tmp/kibana3') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
@@ -99,8 +95,7 @@ describe 'kibana3', :type => :class do
         let (:params) {{ :k3_release => '3a485aa' }}
         it { should compile }
         it { should contain_class('git') }
-        it { should contain_class('apache')\
-          .with_default_vhost(false) }
+        it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with_revision('3a485aa') \
           .that_notifies('Class[Apache::Service]') \
@@ -116,8 +111,7 @@ describe 'kibana3', :type => :class do
         let (:params) {{ :ws_port => '8080' }}
         it { should compile }
         it { should contain_class('git') }
-        it { should contain_class('apache')\
-          .with_default_vhost(false) }
+        it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \


### PR DESCRIPTION
With the way the module is currently written, it is hard to make
it colive with other modules that relies on apache. It will end up
on a Duplicate resource.

By including it, we can still let kibana3 manage webservice (vhost)
but yet colive with other modules. Configuration might be done with
hiera or another solution.
