### PR TITLE
install: Allow one to not retrieve kibana3 from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Should the module manage git.
 **Default:** _true_
 Should the module manage the webserver.
 
+#####`manage_git_repository`
+**Data Type:** _bool_
+**Default:** _true_
+Should the module manage kibana3 git repository.
+
 #####`ws_servername`
 **Data Type:** _string_
 **Default:** _kibana3_

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,9 @@
 # [*manage_git*]
 #   Should the module manage git.
 #
+# [*manage_git_repository*]
+#   Should the module manage the kibana3 git repository.
+#
 # [*manage_ws*]
 #   Should the module manage the webserver.
 #
@@ -88,7 +91,8 @@ class kibana3 (
   $k3_install_folder = $::kibana3::params::k3_install_folder,
   $k3_release        = $::kibana3::params::k3_release,
 
-  $manage_git = $::kibana3::params::manage_git,
+  $manage_git            = $::kibana3::params::manage_git,
+  $manage_git_repository = $::kibana3::params::manage_git_repository,
 
   $manage_ws     = $::kibana3::params::manage_ws,
   $ws_servername = $::kibana3::params::ws_servername,
@@ -100,7 +104,7 @@ class kibana3 (
     $config_es_protocol,$config_es_server,$config_kibana_index,
     $k3_folder_owner,$k3_install_folder,$k3_release,$ws_port)
 
-  validate_bool($manage_git,$manage_ws)
+  validate_bool($manage_git,$manage_ws,$manage_git_repository)
 
   validate_array($config_panel_names)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,16 +19,18 @@ class kibana3::install {
   }
 
   if $::kibana3::manage_ws {
-    vcsrepo {
-      $::kibana3::k3_install_folder:
-      ensure   => present,
-      provider => git,
-      source   => 'https://github.com/elasticsearch/kibana.git',
-      revision => $::kibana3::k3_release,
-      owner    => $_ws_user,
-      notify   => Class['::Apache::Service'],
+    if $::kibana3::manage_git_repository {
+      vcsrepo {
+        $::kibana3::k3_install_folder:
+        ensure   => present,
+        provider => git,
+        source   => 'https://github.com/elasticsearch/kibana.git',
+        revision => $::kibana3::k3_release,
+        owner    => $_ws_user,
+        notify   => Class['::Apache::Service'],
+        before   => Apache::Vhost[$::kibana3::ws_servername],
+      }
     }
-    ->
     apache::vhost {
       $::kibana3::ws_servername :
       port          => $::kibana3::ws_port,
@@ -36,13 +38,15 @@ class kibana3::install {
       docroot_owner => $_ws_user,
     }
   } else {
-    vcsrepo {
-      $::kibana3::k3_install_folder:
-      ensure   => present,
-      provider => git,
-      source   => 'https://github.com/elasticsearch/kibana.git',
-      revision => $::kibana3::k3_release,
-      owner    => $_ws_user,
+    if $::kibana3::manage_git_repository {
+      vcsrepo {
+        $::kibana3::k3_install_folder:
+        ensure   => present,
+        provider => git,
+        source   => 'https://github.com/elasticsearch/kibana.git',
+        revision => $::kibana3::k3_release,
+        owner    => $_ws_user,
+      }
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,8 @@ class kibana3::params {
   $k3_install_folder = '/opt/kibana3'
   $k3_release        = 'a50a913'
 
-  $manage_git = true
+  $manage_git            = true
+  $manage_git_repository = true
 
   $manage_ws     = true
   $ws_servername = 'kibana3'

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -122,6 +122,11 @@ describe 'kibana3', :type => :class do
             'docroot' => '/opt/kibana3/src'
           ) }
       end
+
+      context 'with manage_git_repository set to false' do
+        let (:params) {{ :manage_git_repository => false }}
+        it { should_not contain_vcsrepo('/opt/kibana3') }
+      end
     end
 
   end


### PR DESCRIPTION
My current use case is that we use images based deployment.
So kibana3 is retrieved when we build the image, but then we
deploy the images, in an environment that does not have internet.
We, hence would like to be able, to deactivate the resource as
we need.
