### PR TITLE
Added k3_clone_url parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 .*.sw?
 .bundle
 Gemfile.lock
+.project

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ The folder to install kibana3 into.
 **Default:** _a50a913 (v3.0.1)_
 A tag or branch from the [kibana3](https://github.com/elasticsearch/kibana) repo. Note that you should use the commit hash instead of the tag name (see [issue #5](https://github.com/thejandroman/kibana3/issues/5)) or puppet will overwrite the config.js file.
 
+##### `k3_clone_url`
+**Data Type:** _string_
+**Default:** _https://github.com/elasticsearch/kibana.git_
+URL for the kibana3 git repo.
+
 #####`manage_git`
 **Data Type:** _bool_
 **Default:** _true_

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,9 +42,12 @@
 #   The folder to install kibana3 into.
 #
 # [*k3_release*]
-#   A tag or branch from the https://github.com/elasticsearch/kibana repo. Note
-#   that you should use the commit hash instead of the tag name (see issue #5)
-#   or puppet will overwrite the config.js file.
+#   A tag or branch from the kibana3 git repo. Note that you should use the
+#   commit hash instead of the tag name (see issue #5) or puppet will overwrite
+#   the config.js file.
+#
+# [*k3_clone_url*]
+#   URL for the kibana3 git repo.
 #
 # [*manage_git*]
 #   Should the module manage git.
@@ -90,6 +93,7 @@ class kibana3 (
   $k3_folder_owner   = $::kibana3::params::k3_folder_owner,
   $k3_install_folder = $::kibana3::params::k3_install_folder,
   $k3_release        = $::kibana3::params::k3_release,
+  $k3_clone_url      = $::kibana3::params::k3_clone_url,
 
   $manage_git            = $::kibana3::params::manage_git,
   $manage_git_repository = $::kibana3::params::manage_git_repository,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class kibana3::install {
         $::kibana3::k3_install_folder:
         ensure   => present,
         provider => git,
-        source   => 'https://github.com/elasticsearch/kibana.git',
+        source   => $::kibana3::k3_clone_url,
         revision => $::kibana3::k3_release,
         owner    => $_ws_user,
         notify   => Class['::Apache::Service'],
@@ -43,7 +43,7 @@ class kibana3::install {
         $::kibana3::k3_install_folder:
         ensure   => present,
         provider => git,
-        source   => 'https://github.com/elasticsearch/kibana.git',
+        source   => $::kibana3::k3_clone_url,
         revision => $::kibana3::k3_release,
         owner    => $_ws_user,
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class kibana3::params {
   $k3_folder_owner   = undef
   $k3_install_folder = '/opt/kibana3'
   $k3_release        = 'a50a913'
+  $k3_clone_url      = 'https://github.com/elasticsearch/kibana.git'
 
   $manage_git            = true
   $manage_git_repository = true

--- a/metadata.json
+++ b/metadata.json
@@ -18,8 +18,7 @@
   "source": "https://github.com/thejandroman/kibana3",
   "author": "thejandroman",
   "license": "Apache License, Version 2.0",
-  "summary": "Installs and configures kibana3.",
-  "description": "The kibana3 puppet module allows one to setup and configure the kibana3 interface to Logstash and ElasticSearch.",
+  "summary": "Installs and configures the kibana3 interface to Logstash and ElasticSearch",
   "project_page": "https://github.com/thejandroman/kibana3",
   "dependencies": [
     {
@@ -38,24 +37,5 @@
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.1"
     }
-  ],
-  "types": [
-
-  ],
-  "checksums": {
-    "Gemfile": "bbaaccead6becc002a74caafda1babe8",
-    "LICENSE": "b1b1222427797ff2583a958e2f32e9ef",
-    "Modulefile": "464335b5a25bbf4378d9d04569342b5c",
-    "README.md": "48525ed0bbaf2620e08cfdb38b8dbbd5",
-    "Rakefile": "d884be2a35803faeeead87cb61a64647",
-    "manifests/config.pp": "61ea33cec8d30b5efa320a3e453f7419",
-    "manifests/init.pp": "fcc1858f8078d12760656cde6f7c1aae",
-    "manifests/install.pp": "52781d5febae418d77f1fe10acf5cb08",
-    "manifests/params.pp": "50801b9db7a6eaeb80e90248228f0bed",
-    "manifests/uninstall.pp": "0f044aefcbf3e97b8eb88feed710433a",
-    "spec/classes/kibana3_init_spec.rb": "39204446eacdcf9d3f94908f1f857592",
-    "spec/spec_helper.rb": "3ea886dd135e120afa31e0aab12e85b0",
-    "templates/config.js.erb": "74fd6df7467defc5fe2493ee4135a0b2",
-    "tests/init.pp": "5a0f09e3fbda7c532e0b763733bc0094"
-  }
+  ]
 }


### PR DESCRIPTION
Security policies may prevent some hosts from directly accessing GitHub and other hosts on the public Internet. This commit adds the k3_clone_url parameter to allow the use of an internal clone of the public repo. It also includes an update to .gitignore and removes deprecated fields from metadata.json.