### PR TITLE
Added k3_clone_url parameter for deployment from an internal git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ The folder to install kibana3 into.
 **Default:** _a50a913 (v3.0.1)_
 A tag or branch from the [kibana3](https://github.com/elasticsearch/kibana) repo. Note that you should use the commit hash instead of the tag name (see [issue #5](https://github.com/thejandroman/kibana3/issues/5)) or puppet will overwrite the config.js file.
 
+##### `k3_clone_url`
+**Data Type:** _string_
+**Default:** _https://github.com/elasticsearch/kibana.git_
+URL for the kibana3 git repo.
+
 #####`manage_git`
 **Data Type:** _bool_
 **Default:** _true_

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,9 +42,12 @@
 #   The folder to install kibana3 into.
 #
 # [*k3_release*]
-#   A tag or branch from the https://github.com/elasticsearch/kibana repo. Note
-#   that you should use the commit hash instead of the tag name (see issue #5)
-#   or puppet will overwrite the config.js file.
+#   A tag or branch from the kibana3 git repo. Note that you should use the
+#   commit hash instead of the tag name (see issue #5) or puppet will overwrite
+#   the config.js file.
+#
+# [*k3_clone_url*]
+#   URL for the kibana3 git repo.
 #
 # [*manage_git*]
 #   Should the module manage git.
@@ -90,6 +93,7 @@ class kibana3 (
   $k3_folder_owner   = $::kibana3::params::k3_folder_owner,
   $k3_install_folder = $::kibana3::params::k3_install_folder,
   $k3_release        = $::kibana3::params::k3_release,
+  $k3_clone_url      = $::kibana3::params::k3_clone_url,
 
   $manage_git            = $::kibana3::params::manage_git,
   $manage_git_repository = $::kibana3::params::manage_git_repository,
@@ -102,7 +106,8 @@ class kibana3 (
 
   validate_string($ensure,$config_default_route,$config_es_port,
     $config_es_protocol,$config_es_server,$config_kibana_index,
-    $k3_folder_owner,$k3_install_folder,$k3_release,$ws_port)
+    $k3_folder_owner,$k3_install_folder,$k3_release,$k3_clone_url,
+    $ws_port)
 
   validate_bool($manage_git,$manage_ws,$manage_git_repository)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class kibana3::install {
         $::kibana3::k3_install_folder:
         ensure   => present,
         provider => git,
-        source   => 'https://github.com/elasticsearch/kibana.git',
+        source   => $::kibana3::k3_clone_url,
         revision => $::kibana3::k3_release,
         owner    => $_ws_user,
         notify   => Class['::Apache::Service'],
@@ -43,7 +43,7 @@ class kibana3::install {
         $::kibana3::k3_install_folder:
         ensure   => present,
         provider => git,
-        source   => 'https://github.com/elasticsearch/kibana.git',
+        source   => $::kibana3::k3_clone_url,
         revision => $::kibana3::k3_release,
         owner    => $_ws_user,
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class kibana3::params {
   $k3_folder_owner   = undef
   $k3_install_folder = '/opt/kibana3'
   $k3_release        = 'a50a913'
+  $k3_clone_url      = 'https://github.com/elasticsearch/kibana.git'
 
   $manage_git            = true
   $manage_git_repository = true

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -16,6 +16,7 @@ describe 'kibana3', :type => :class do
         it { should contain_class('git') }
         it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
+          .with_source('https://github.com/elasticsearch/kibana.git') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
           .that_comes_before('Apache::Vhost[kibana3]') }
@@ -32,6 +33,7 @@ describe 'kibana3', :type => :class do
         it { should_not contain_class('git') }
         it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
+          .with_source('https://github.com/elasticsearch/kibana.git') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
           .that_comes_before('Apache::Vhost[kibana3]') }
@@ -49,6 +51,7 @@ describe 'kibana3', :type => :class do
         it { should_not contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with(
+            'source'   => 'https://github.com/elasticsearch/kibana.git',
             'revision' => 'a50a913',
             'owner'    => 'root'
           ) }
@@ -62,6 +65,7 @@ describe 'kibana3', :type => :class do
         it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
           .with(
+            'source'   => 'https://github.com/elasticsearch/kibana.git',
             'revision' => 'a50a913',
             'owner'    => 'foo'
           ) \
@@ -81,6 +85,7 @@ describe 'kibana3', :type => :class do
         it { should contain_class('git') }
         it { should contain_class('apache') }
         it { should contain_vcsrepo('/tmp/kibana3') \
+          .with_source('https://github.com/elasticsearch/kibana.git') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
           .that_comes_before('Apache::Vhost[kibana3]') }
@@ -97,6 +102,7 @@ describe 'kibana3', :type => :class do
         it { should contain_class('git') }
         it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
+          .with_source('https://github.com/elasticsearch/kibana.git') \
           .with_revision('3a485aa') \
           .that_notifies('Class[Apache::Service]') \
           .that_comes_before('Apache::Vhost[kibana3]') }
@@ -107,12 +113,35 @@ describe 'kibana3', :type => :class do
           ) }
       end
 
+      context 'with non-standard clone url' do
+        let (:params) {{ :k3_clone_url => 'http://git.io/hXZlwA' }}
+        it { should compile }
+        it { should contain_class('git') }
+        it { should contain_class('apache') }
+        it { should contain_vcsrepo('/opt/kibana3') \
+          .with_source('http://git.io/hXZlwA') \
+          .with_revision('a50a913') \
+          .that_notifies('Class[Apache::Service]') \
+          .that_comes_before('Apache::Vhost[kibana3]') }
+      end
+
+      context 'with non-standard clone url and no webserver' do
+        let (:params) {{ :k3_clone_url => 'http://git.io/hXZlwA', :manage_ws => false }}
+        it { should compile }
+        it { should contain_class('git') }
+        it { should_not contain_class('apache') }
+        it { should contain_vcsrepo('/opt/kibana3') \
+          .with_source('http://git.io/hXZlwA') \
+          .with_revision('a50a913') }
+      end
+
       context 'with non-standard port' do
         let (:params) {{ :ws_port => '8080' }}
         it { should compile }
         it { should contain_class('git') }
         it { should contain_class('apache') }
         it { should contain_vcsrepo('/opt/kibana3') \
+          .with_source('https://github.com/elasticsearch/kibana.git') \
           .with_revision('a50a913') \
           .that_notifies('Class[Apache::Service]') \
           .that_comes_before('Apache::Vhost[kibana3]') }


### PR DESCRIPTION
I have added a parameter for specifying an alternate Kibana repository URL for cases where Internet access is restricted along with updated rspec tests for full coverage.