### PR TITLE
Added parameter config_es_suffix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The protocol (http/https) of the elasticsearch server. Because kibana3 is browse
 **Default:** _"+window.location.hostname+"_
 The FQDN of the elasticsearch server. Because kibana3 is browser based this must be accessible from the browser loading kibana3.
 
+#####`config_es_suffix`
+**Data Type:** _string_
+**Default:** _""_
+Adds suffix to elastaicsearch url. Beacuse sometimes (expecialy with combination with apache or other proxy) elasticsearch is not in server root, but in some sub url. 
+
 #####`config_kibana_index`
 **Data Type:** _string_
 **Default:** _kibana-int_

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,10 @@
 #   The FQDN of the elasticsearch server. Because kibana3 is browser based
 #   this must be accessible from the browser loading kibana3.
 #
+# [*config_es_suffix*]
+#   Adds suffix to elastaicsearch url. Beacuse sometimes (expecialy with 
+#   combination with apache or other proxy) elasticsearch is not in server root, but in some sub url.
+#
 # [*config_kibana_index*]
 #   The default ES index to use for storing Kibana specific object such as
 #   stored dashboards.
@@ -92,6 +96,7 @@ class kibana3 (
   $config_es_port       = $::kibana3::params::config_es_port,
   $config_es_protocol   = $::kibana3::params::config_es_protocol,
   $config_es_server     = $::kibana3::params::config_es_server,
+  $config_es_suffix     = $::kibana3::params::config_es_suffix,
   $config_kibana_index  = $::kibana3::params::config_kibana_index,
   $config_panel_names   = $::kibana3::params::config_panel_names,
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class kibana3::params {
   $config_es_protocol   = 'http'
   $config_es_server     = '"+window.location.hostname+"'
   $config_kibana_index  = 'kibana-int'
+  $config_es_suffix     = ''
   $config_panel_names   = [
     'histogram',
     'map',

--- a/metadata.json
+++ b/metadata.json
@@ -7,19 +7,19 @@
     "source": "https://github.com/thejandroman/puppet-kibana3",
     "dependencies": [
         {
-            "name": "puppetlabs/git",
-            "version_requirement": "0.x"
+            "name": "puppetlabs-git",
+            "version_requirement": ">=0.3.0"
         },
         {
-            "name": "puppetlabs/vcsrepo",
+            "name": "puppetlabs-vcsrepo",
             "version_requirement": ">=0.1.0 <=1.3.1"
         },
         {
-            "name": "puppetlabs/apache",
+            "name": "puppetlabs-apache",
             "version_requirement": ">=0.10.0 <=1.6.0"
         },
         {
-            "name": "puppetlabs/stdlib",
+            "name": "puppetlabs-stdlib",
             "version_requirement": ">=3.2.0 <5.0.0"
         }
     ],

--- a/metadata.json
+++ b/metadata.json
@@ -4,19 +4,11 @@
     "author": "thejandroman",
     "license": "Apache-2.0",
     "summary": "Installs and configures kibana3.",
-    "source": "https://github.com/thejandroman/puppet-kibana3",
+    "source": "https://github.com/marianschmotzer/puppet-kibana3.git",
     "dependencies": [
         {
             "name": "puppetlabs-git",
             "version_requirement": ">=0.3.0"
-        },
-        {
-            "name": "puppetlabs-vcsrepo",
-            "version_requirement": ">=0.1.0 <=1.3.1"
-        },
-        {
-            "name": "puppetlabs-apache",
-            "version_requirement": ">=0.10.0 <=1.6.0"
         },
         {
             "name": "puppetlabs-stdlib",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -107,6 +107,18 @@ describe 'kibana3', :type => :class do
           .that_notifies('Class[Apache::Service]')
         }
       end
+      
+      context 'with non-standard elasticsearch server url suffix' do
+        let (:params) {{ :config_es_suffix => '' }}
+        it { should compile }
+        it { should contain_file('/opt/kibana3/src/config.js') \
+          .with_content(/^\s*elasticsearch: \"http:\/\/\localhost:9200\",$/) \
+          .with_content(/^\s*default_route: '\/dashboard\/file\/default\.json',$/) \
+          .with_content(/^\s*kibana_index: \"kibana-int\",$/) \
+          .with_content(/^\s*panel_names: \[\s*'histogram',\s*'map',\s*'goal',\s*'table',\s*'filtering',\s*'timepicker',\s*'text',\s*'hits',\s*'column',\s*'trends',\s*'bettermap',\s*'query',\s*'terms',\s*'stats',\s*'sparklines',\s*\]$/) \
+          .that_notifies('Class[Apache::Service]')
+        }
+      end
 
       context 'with non-standard kibana index' do
         let (:params) {{ :config_kibana_index => 'kibana-index' }}

--- a/templates/config.js.erb
+++ b/templates/config.js.erb
@@ -8,7 +8,7 @@ function (Settings) {
 
   return new Settings({
 
-    elasticsearch: "<%= scope['::kibana3::config_es_protocol'] %>://<%= scope['::kibana3::config_es_server'] %>:<%= scope['::kibana3::config_es_port'] %>",
+    elasticsearch: "<%= scope['::kibana3::config_es_protocol'] %>://<%= scope['::kibana3::config_es_server'] %>:<%= scope['::kibana3::config_es_port'] %>/<%= scope['::kibana3::config_es_suffix'] %>",
 
     default_route: '<%= scope['::kibana3::config_default_route'] %>',
 


### PR DESCRIPTION
to have option to put alternative suffix for elasticsearch root url (maybe needed if you use es behind nginx/apache)
